### PR TITLE
Expose run_metadata and options in compiled_tcn()

### DIFF
--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -155,7 +155,9 @@ def compiled_tcn(
         dropout_rate=0.05,  # type: float
         name='tcn',  # type: str,
         opt='adam',
-        lr=0.002):
+        lr=0.002,
+        options=None,
+        run_metadata=None):
     # type: (...) -> keras.Model
     """Creates a compiled TCN model for a given task (i.e. regression or classification).
     Classification uses a sparse categorical loss. Please input class ids and not one-hot encodings.
@@ -228,14 +230,21 @@ def compiled_tcn(
         model.compile(
             get_opt(),
             loss='sparse_categorical_crossentropy',
-            metrics=[accuracy])
+            metrics=[accuracy],
+            options=options,
+            run_metadata=run_metadata)
     else:
         # regression
         x = Dense(1)(x)
         x = Activation('linear')(x)
         output_layer = x
         model = Model(input_layer, output_layer)
-        model.compile(get_opt(), loss='mean_squared_error')
+        model.compile(
+            get_opt(),
+            loss='mean_squared_error',
+            options=options,
+            run_metadata=run_metadata)
+
     print(f'model.x = {input_layer.shape}')
     print(f'model.y = {output_layer.shape}')
     return model


### PR DESCRIPTION
This exposes Tensorflow's [`run_metadata` and `options` parameters in the `compiled_tcn()` function](https://www.tensorflow.org/api_docs/python/tf/keras/models/Model#compile) in order to allow us to profile using the Tensorflow profiling tools (see viaduct-ai/backlog#69)